### PR TITLE
[PW-22] 채팅방 생성 및 채팅방 목록

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,7 @@ import { AuthContext } from "./contexts/AuthContext";
 import LostAnimalUpdate from "./pages/lostanimal/LostAnimalUpdate.jsx";
 import ChatRoom from "./pages/chat/ChatRoom.jsx";
 import ChatRooms from './pages/chat/ChatRooms';
+import ChatRoomsByPost from './pages/chat/ChatRoomsByPost';
 
 function App() {
   const { user } = useContext(AuthContext);
@@ -40,6 +41,10 @@ function App() {
           path="chat/:roomId" element={<ChatRoom />}
         />
         <Route path="chatrooms" element={<ChatRooms />} />
+        <Route 
+          path="chatrooms/post/:postId" 
+          element={user ? <ChatRoomsByPost /> : <Navigate to="/login" replace />} 
+        />
       </Route>
     </Routes>
   );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,7 @@ import AdditionalInfo from "./pages/signup/AdditionalInfo.jsx";
 import { AuthContext } from "./contexts/AuthContext";
 import LostAnimalUpdate from "./pages/lostanimal/LostAnimalUpdate.jsx";
 import ChatRoom from "./pages/chat/ChatRoom.jsx";
+import ChatRooms from './pages/chat/ChatRooms';
 
 function App() {
   const { user } = useContext(AuthContext);
@@ -38,6 +39,7 @@ function App() {
         <Route 
           path="chat/:roomId" element={<ChatRoom />}
         />
+        <Route path="chatrooms" element={<ChatRooms />} />
       </Route>
     </Routes>
   );

--- a/src/components/layout/Header.css
+++ b/src/components/layout/Header.css
@@ -27,7 +27,7 @@
 .desktop-menu {
   display: flex;
   align-items: center;
-  gap: 24px; /* 알림 버튼과 사용자 이미지 사이 간격 */
+  gap: 20px;
 }
 
 .main-nav {

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -153,6 +153,11 @@ function Header() {
                 )}
               </div>
             </li>
+            <li className="tab-item">
+              <NavLink to="/chatrooms" className={({ isActive }) => (isActive ? "active" : "")}>
+                채팅 목록
+              </NavLink>
+            </li>
                 </>
                 )}
           </ul>

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -154,10 +154,16 @@ function Header() {
                         )}
                       </div>
                     </li>
+                    <li className="tab-item">
+                      <NavLink to="/chatrooms" className={({ isActive }) => (isActive ? "active" : "")}>
+                        채팅 목록
+                      </NavLink>
+                    </li>
                   </>
               )}
             </ul>
           </nav>
+
           <NotificationButton />
           <div className="user" onClick={handleUserClick}>
             <img src={userImage} alt="user-img" className="user-img"/>
@@ -189,6 +195,11 @@ function Header() {
               <li className="tab-item">
                 <NavLink to="/adoptions" className={({ isActive }) => (isActive ? "active" : "")} onClick={handleMenuClick}>
                   입양 동물
+                </NavLink>
+              </li>
+              <li className="tab-item">
+                <NavLink to="/chatrooms" className={({ isActive }) => (isActive ? "active" : "")} onClick={handleMenuClick}>
+                  채팅 목록
                 </NavLink>
               </li>
               <li className="tab-item mobile-dropdown-container">

--- a/src/pages/chat/ChatRooms.css
+++ b/src/pages/chat/ChatRooms.css
@@ -37,6 +37,13 @@
   background-color: #f5f5f5;
 }
 
+/* 새 메시지 도착 강조 */
+.chat-room-item.new-message {
+  border-color: #3B82F6;            /* 파란색 테두리 */
+  box-shadow: 0 0 8px rgba(59, 130, 246, 0.5);
+  transition: box-shadow 0.3s ease;
+}
+
 .chat-room-item:hover {
   transform: translateY(-2px);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);

--- a/src/pages/chat/ChatRooms.css
+++ b/src/pages/chat/ChatRooms.css
@@ -110,10 +110,22 @@
   color: #FF8A3D;
   font-size: 14px;
   cursor: pointer;
+  padding: 6px 12px;
+  border-radius: 4px;
+  transition: all 0.2s ease;
+  position: relative;
+  background-color: rgba(255, 138, 61, 0.05);
 }
 
 .post-link:hover {
-  text-decoration: underline;
+  background-color: rgba(255, 138, 61, 0.1);
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(255, 138, 61, 0.2);
+}
+
+.post-link:active {
+  transform: translateY(0);
+  box-shadow: 0 1px 4px rgba(255, 138, 61, 0.1);
 }
 
 .no-chat-rooms {

--- a/src/pages/chat/ChatRooms.css
+++ b/src/pages/chat/ChatRooms.css
@@ -1,0 +1,127 @@
+.chat-rooms-container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+.chat-rooms-container h1 {
+  text-align: center;
+  margin-bottom: 30px;
+  color: #333;
+}
+
+.chat-rooms-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.chat-room-item {
+  display: flex;
+  padding: 16px;
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.chat-room-item:hover {
+  transform: translateY(-2px);
+}
+
+.chat-room-item.inactive {
+  opacity: 0.7;
+}
+
+.chat-room-image {
+  width: 100px;
+  height: 100px;
+  margin-right: 16px;
+  flex-shrink: 0;
+}
+
+.chat-room-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 4px;
+}
+
+.chat-room-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  position: relative;
+}
+
+.chat-room-kind {
+  font-size: 16px;
+  font-weight: bold;
+  margin-bottom: 8px;
+  color: #333;
+}
+
+.chat-room-location {
+  font-size: 14px;
+  color: #666;
+  margin-bottom: 4px;
+}
+
+.chat-room-author {
+  font-size: 14px;
+  color: #666;
+}
+
+.post-link {
+  position: absolute;
+  top: 50%;
+  right: 0;
+  transform: translateY(-50%);
+  color: #FF8A3D;
+  font-size: 14px;
+  cursor: pointer;
+  padding: 8px;
+  border-radius: 4px;
+  transition: background-color 0.2s;
+}
+
+.post-link:hover {
+  background-color: rgba(255, 138, 61, 0.1);
+}
+
+.chat-room-status {
+  color: #FF8A3D;
+  font-size: 14px;
+  margin-top: 8px;
+}
+
+.no-chat-rooms {
+  text-align: center;
+  padding: 40px;
+  color: #666;
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+@media (max-width: 600px) {
+  .chat-rooms-container {
+    padding: 16px;
+  }
+
+  .chat-room-image {
+    width: 80px;
+    height: 80px;
+  }
+
+  .chat-room-kind {
+    font-size: 14px;
+  }
+
+  .post-link {
+    font-size: 12px;
+    padding: 6px;
+  }
+} 

--- a/src/pages/chat/ChatRooms.css
+++ b/src/pages/chat/ChatRooms.css
@@ -16,14 +16,25 @@
   gap: 16px;
 }
 
+/* 공통: 기본 테두리 두께를 2px로 */
 .chat-room-item {
   display: flex;
   padding: 16px;
-  border: 1px solid #e0e0e0;
+  border: 2px solid #e0e0e0;
   border-radius: 8px;
   cursor: pointer;
   transition: all 0.2s ease;
   background-color: white;
+}
+
+/* 활성 채팅방은 진한 테두리, 비활성은 연한/회색 테두리 */
+.chat-room-item:not(.inactive) {
+  border-color: #333;
+}
+.chat-room-item.inactive {
+  border-color: #ccc;
+  opacity: 0.7;
+  background-color: #f5f5f5;
 }
 
 .chat-room-item:hover {
@@ -52,26 +63,57 @@
   justify-content: space-between;
 }
 
+/* ------------ 헤더 스타일링 ------------ */
 .chat-room-header {
   display: flex;
   align-items: center;
-  gap: 12px;
   margin-bottom: 8px;
-  position: relative;
+
 }
 
-.chat-room-kind {
-  font-weight: 600;
-  color: #FF8A3D;
+/* 사용자명 / 나의 공고 */
+.chat-room-header-user {
   font-size: 16px;
+  font-weight: 600;
+  color: #333;
 }
 
-.chat-room-location {
-  color: #666;
+/* 구분자 | */
+.chat-room-header-sep {
+  margin: 0 8px;
+  color: #999;
+  user-select: none;
+}
+
+/* 실종/발견 레이블 */
+.chat-room-header-type {
+  font-size: 17px;
+  font-weight: 500;
+}
+
+.chat-room-header-type.lost {
+  color: #FF8A3D;
+}
+
+/* 발견(found) → 녹색 */
+.chat-room-header-type.found {
+  color: #2ea043;
+}
+
+
+/* 상태(🟢 진행중 / 🔴 종료됨) */
+.chat-room-status {
   font-size: 14px;
-  flex: 1;
+  margin-left: auto;
+}
+.chat-room-status.active {
+  color: #2ea043;
+}
+.chat-room-status.inactive {
+  color: #ff4444;
 }
 
+/* ------------ 메시지 영역 ------------ */
 .chat-room-message {
   color: #333;
   font-size: 15px;
@@ -79,6 +121,7 @@
   flex: 1;
 }
 
+/* ------------ 푸터 스타일링 ------------ */
 .chat-room-footer {
   display: flex;
   align-items: center;
@@ -91,21 +134,7 @@
   font-size: 14px;
 }
 
-.chat-room-status {
-  font-size: 14px;
-  position: absolute;
-  right: 0;
-  top: 0;
-}
-
-.chat-room-status.active {
-  color: #2ea043;
-}
-
-.chat-room-status.inactive {
-  color: #ff4444;
-}
-
+/* “공고로 이동” 버튼 */
 .post-link {
   color: #FF8A3D;
   font-size: 14px;
@@ -113,16 +142,13 @@
   padding: 6px 12px;
   border-radius: 4px;
   transition: all 0.2s ease;
-  position: relative;
   background-color: rgba(255, 138, 61, 0.05);
 }
-
 .post-link:hover {
   background-color: rgba(255, 138, 61, 0.1);
   transform: translateY(-1px);
   box-shadow: 0 2px 8px rgba(255, 138, 61, 0.2);
 }
-
 .post-link:active {
   transform: translateY(0);
   box-shadow: 0 1px 4px rgba(255, 138, 61, 0.1);
@@ -137,11 +163,6 @@
   border-radius: 8px;
 }
 
-.inactive {
-  opacity: 0.7;
-  background-color: #f5f5f5;
-}
-
 @media (max-width: 600px) {
   .chat-rooms-container {
     padding: 16px;
@@ -152,12 +173,20 @@
     height: 80px;
   }
 
-  .chat-room-kind {
+  .chat-room-header-user {
     font-size: 14px;
+  }
+
+  .chat-room-header-sep {
+    margin: 0 6px;
+  }
+
+  .chat-room-header-type {
+    font-size: 12px;
   }
 
   .post-link {
     font-size: 12px;
     padding: 6px;
   }
-} 
+}

--- a/src/pages/chat/ChatRooms.css
+++ b/src/pages/chat/ChatRooms.css
@@ -19,19 +19,16 @@
 .chat-room-item {
   display: flex;
   padding: 16px;
-  background: white;
+  border: 1px solid #e0e0e0;
   border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   cursor: pointer;
-  transition: transform 0.2s ease;
+  transition: all 0.2s ease;
+  background-color: white;
 }
 
 .chat-room-item:hover {
   transform: translateY(-2px);
-}
-
-.chat-room-item.inactive {
-  opacity: 0.7;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
 }
 
 .chat-room-image {
@@ -45,65 +42,92 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
-  border-radius: 4px;
+  border-radius: 8px;
 }
 
 .chat-room-info {
   flex: 1;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: space-between;
+}
+
+.chat-room-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 8px;
   position: relative;
 }
 
 .chat-room-kind {
+  font-weight: 600;
+  color: #FF8A3D;
   font-size: 16px;
-  font-weight: bold;
-  margin-bottom: 8px;
-  color: #333;
 }
 
 .chat-room-location {
-  font-size: 14px;
   color: #666;
-  margin-bottom: 4px;
+  font-size: 14px;
+  flex: 1;
+}
+
+.chat-room-message {
+  color: #333;
+  font-size: 15px;
+  margin: 8px 0;
+  flex: 1;
+}
+
+.chat-room-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 8px;
 }
 
 .chat-room-author {
-  font-size: 14px;
   color: #666;
-}
-
-.post-link {
-  position: absolute;
-  top: 50%;
-  right: 0;
-  transform: translateY(-50%);
-  color: #FF8A3D;
   font-size: 14px;
-  cursor: pointer;
-  padding: 8px;
-  border-radius: 4px;
-  transition: background-color 0.2s;
-}
-
-.post-link:hover {
-  background-color: rgba(255, 138, 61, 0.1);
 }
 
 .chat-room-status {
+  font-size: 14px;
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+
+.chat-room-status.active {
+  color: #2ea043;
+}
+
+.chat-room-status.inactive {
+  color: #ff4444;
+}
+
+.post-link {
   color: #FF8A3D;
   font-size: 14px;
-  margin-top: 8px;
+  cursor: pointer;
+}
+
+.post-link:hover {
+  text-decoration: underline;
 }
 
 .no-chat-rooms {
   text-align: center;
   padding: 40px;
   color: #666;
-  background: white;
+  font-size: 16px;
+  background-color: #f5f5f5;
   border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.inactive {
+  opacity: 0.7;
+  background-color: #f5f5f5;
 }
 
 @media (max-width: 600px) {

--- a/src/pages/chat/ChatRooms.jsx
+++ b/src/pages/chat/ChatRooms.jsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useState, useContext } from 'react';
+import React, { useEffect, useState, useContext, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import client from '../../api/client';
 import { AuthContext } from '../../contexts/AuthContext';
 import './ChatRooms.css';
+import WebSocketService from '../../services/WebSocketService';
 
 function ChatRooms() {
   const [chatRooms, setChatRooms] = useState([]);
@@ -10,6 +11,10 @@ function ChatRooms() {
   const [error, setError] = useState(null);
   const navigate = useNavigate();
   const { isLoggedIn, user } = useContext(AuthContext);
+  
+  // 구독 상태를 추적하기 위한 ref
+  const subscribedRoomsRef = useRef(new Set());
+  const isWebSocketConnectedRef = useRef(false);
 
   useEffect(() => {
     if (!isLoggedIn) {
@@ -32,6 +37,126 @@ function ChatRooms() {
 
     fetchChatRooms();
   }, [isLoggedIn, navigate]);
+
+  // WebSocket 연결은 한 번만 수행
+  useEffect(() => {
+    if (!isLoggedIn) return;
+
+    const connectWebSocket = async () => {
+      try {
+        if (!isWebSocketConnectedRef.current) {
+          await WebSocketService.connect();
+          isWebSocketConnectedRef.current = true;
+          console.log('[ChatRooms] WebSocket connected');
+        }
+      } catch (error) {
+        console.error('WebSocket 연결 오류:', error);
+        isWebSocketConnectedRef.current = false;
+      }
+    };
+
+    connectWebSocket();
+
+    // 컴포넌트 언마운트 시 모든 구독 해지 및 연결 해제
+    return () => {
+      console.log('[ChatRooms] Cleaning up all subscriptions...');
+      
+      // 모든 구독 해지
+      subscribedRoomsRef.current.forEach(roomId => {
+        const destination = `/user/queue/chat/${roomId}`;
+        WebSocketService.unsubscribe(destination);
+      });
+      
+      subscribedRoomsRef.current.clear();
+      isWebSocketConnectedRef.current = false;
+      
+      // WebSocket 연결 해제
+      WebSocketService.disconnect();
+    };
+  }, [isLoggedIn]);
+
+  // 채팅방 목록이 변경될 때 구독 관리
+  useEffect(() => {
+    if (!isLoggedIn || chatRooms.length === 0 || !isWebSocketConnectedRef.current) return;
+
+    const manageSubscriptions = () => {
+      const activeRoomIds = new Set(
+        chatRooms
+          .filter(room => room.status === 'ACTIVE')
+          .map(room => room.chatRoomId)
+      );
+
+      // 더 이상 활성화되지 않은 방의 구독 해지
+      subscribedRoomsRef.current.forEach(roomId => {
+        if (!activeRoomIds.has(roomId)) {
+          const destination = `/user/queue/chat/${roomId}`;
+          WebSocketService.unsubscribe(destination);
+          subscribedRoomsRef.current.delete(roomId);
+          console.log(`[ChatRooms] Unsubscribed from room ${roomId}`);
+        }
+      });
+
+      // 새로운 활성 방에 구독
+      activeRoomIds.forEach(roomId => {
+        if (!subscribedRoomsRef.current.has(roomId)) {
+          const destination = `/user/queue/chat/${roomId}`;
+          const subscription = WebSocketService.subscribe(
+            destination,
+            (message) => {
+              const receivedMessage = JSON.parse(message.body);
+              setChatRooms(prevRooms =>
+                prevRooms.map(r =>
+                  r.chatRoomId === roomId
+                    ? { ...r, latestMessageContent: receivedMessage.content }
+                    : r
+                )
+              );
+            }
+          );
+          
+          if (subscription) {
+            subscribedRoomsRef.current.add(roomId);
+            console.log(`[ChatRooms] Subscribed to room ${roomId}`);
+          }
+        }
+      });
+    };
+
+    // WebSocket이 연결된 상태에서만 구독 관리
+    if (WebSocketService.isConnected()) {
+      manageSubscriptions();
+    } else {
+      // WebSocket이 연결되지 않은 경우 재연결 시도
+      const reconnectAndSubscribe = async () => {
+        try {
+          await WebSocketService.connect();
+          isWebSocketConnectedRef.current = true;
+          manageSubscriptions();
+        } catch (error) {
+          console.error('WebSocket 재연결 실패:', error);
+        }
+      };
+      reconnectAndSubscribe();
+    }
+  }, [chatRooms, isLoggedIn]);
+
+  // 페이지 언로드 시 정리
+  useEffect(() => {
+    const handleBeforeUnload = () => {
+      console.log('[ChatRooms] Page unloading, cleaning up...');
+      subscribedRoomsRef.current.forEach(roomId => {
+        const destination = `/user/queue/chat/${roomId}`;
+        WebSocketService.unsubscribe(destination);
+      });
+      WebSocketService.disconnect();
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, []);
 
   const handleChatRoomClick = (chatRoomId) => {
     navigate(`/chat/${chatRoomId}`);
@@ -61,6 +186,7 @@ function ChatRooms() {
               <div className="chat-room-info">
                 <div className="chat-room-header">
                   <span className="chat-room-kind">{room.lostPostInfo.kindNm}</span>
+                  <span className="chat-room-type">{room.lostPostInfo.postType}</span>
                   <span className="chat-room-location">{room.lostPostInfo.location}</span>
                   <span className={`chat-room-status ${room.status.toLowerCase()}`}>
                     {room.status === 'ACTIVE' ? '🟢 진행중' : '🔴 종료됨'}
@@ -95,4 +221,4 @@ function ChatRooms() {
   );
 }
 
-export default ChatRooms; 
+export default ChatRooms;

--- a/src/pages/chat/ChatRooms.jsx
+++ b/src/pages/chat/ChatRooms.jsx
@@ -59,20 +59,27 @@ function ChatRooms() {
                 <img src={room.lostPostInfo.imageUrl} alt="분실동물" />
               </div>
               <div className="chat-room-info">
-                <div className="chat-room-kind">{room.lostPostInfo.kindNm}</div>
-                <div className="chat-room-location">{room.lostPostInfo.location}</div>
-                <div className="chat-room-author">작성자: {room.lostPostInfo.author}</div>
-                {room.status === 'INACTIVE' && (
-                  <div className="chat-room-status">종료된 채팅</div>
-                )}
-                <div 
-                  className="post-link"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    navigate(`/lostAnimal/detail/${room.lostPostInfo.postId}`);
-                  }}
-                >
-                  공고로 이동 &gt;
+                <div className="chat-room-header">
+                  <span className="chat-room-kind">{room.lostPostInfo.kindNm}</span>
+                  <span className="chat-room-location">{room.lostPostInfo.location}</span>
+                  <span className={`chat-room-status ${room.status.toLowerCase()}`}>
+                    {room.status === 'ACTIVE' ? '🟢 진행중' : '🔴 종료됨'}
+                  </span>
+                </div>
+                <div className="chat-room-message">
+                  {room.latestMessageContent || "새로운 채팅을 시작해보세요!"}
+                </div>
+                <div className="chat-room-footer">
+                  <span className="chat-room-author">공고 작성자: {room.lostPostInfo.author}</span>
+                  <span 
+                    className="post-link"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      navigate(`/lostAnimal/detail/${room.lostPostInfo.postId}`);
+                    }}
+                  >
+                    공고로 이동 &gt;
+                  </span>
                 </div>
               </div>
             </div>

--- a/src/pages/chat/ChatRooms.jsx
+++ b/src/pages/chat/ChatRooms.jsx
@@ -174,47 +174,66 @@ function ChatRooms() {
             진행 중인 채팅이 없습니다.
           </div>
         ) : (
-          chatRooms.map((room) => (
-            <div
-              key={room.chatRoomId}
-              className={`chat-room-item ${room.status === 'INACTIVE' ? 'inactive' : ''}`}
-              onClick={() => handleChatRoomClick(room.chatRoomId)}
-            >
-              <div className="chat-room-image">
-                <img src={room.lostPostInfo.imageUrl} alt="분실동물" />
+          chatRooms.map((room) => {
+            const isAuthor = user?.userId === room.lostPostInfo.authorId;
+            const postTypeLabel = room.lostPostInfo.postType === 'LOST' ? '실종' : '발견';
+            
+            return (
+              <div
+                key={room.chatRoomId}
+                className={`chat-room-item ${room.status === 'INACTIVE' ? 'inactive' : ''}`}
+                onClick={() => handleChatRoomClick(room.chatRoomId)}
+              >
+                <div className="chat-room-image">
+                  <img src={room.lostPostInfo.imageUrl} alt="분실동물" />
+                </div>
+                <div className="chat-room-info">
+                  
+                  {/* ← 수정된 헤더 */}
+                  <div className="chat-room-header">
+                    <span className="chat-room-header-user">
+                      {isAuthor ? '나의 공고' : room.lostPostInfo.author}
+                    </span>
+                    <span className="chat-room-header-sep">|</span>
+                    <span className={`
+                      chat-room-header-type
+                      ${room.lostPostInfo.postType === 'LOST' ? 'lost' : 'found'}
+                      `}
+                    >
+                      {postTypeLabel}
+                    </span>
+                    <span className={`chat-room-status ${room.status.toLowerCase()}`}>
+                      {room.status === 'ACTIVE' ? '🟢' : '🔴'}
+                    </span>
+                  </div>
+                  
+                  {/* 메시지 영역은 그대로 */}
+                  <div className="chat-room-message">
+                    {room.latestMessageContent || "새로운 채팅을 시작해보세요!"}
+                  </div>
+                  
+                  {/* ← 수정된 푸터 */}
+                  <div className="chat-room-footer">
+                    <span className="chat-room-author">
+                      {isAuthor
+                        ? `${room.participantUserName}님`
+                        : room.lostPostInfo.location
+                      }
+                    </span>
+                    <span
+                      className="post-link"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        navigate(`/lostAnimal/detail/${room.lostPostInfo.postId}`);
+                      }}
+                    >
+                      공고로 이동 &gt;
+                    </span>
+                  </div>
+                </div>
               </div>
-              <div className="chat-room-info">
-                <div className="chat-room-header">
-                  <span className="chat-room-kind">{room.lostPostInfo.kindNm}</span>
-                  <span className="chat-room-type">{room.lostPostInfo.postType}</span>
-                  <span className="chat-room-location">{room.lostPostInfo.location}</span>
-                  <span className={`chat-room-status ${room.status.toLowerCase()}`}>
-                    {room.status === 'ACTIVE' ? '🟢 진행중' : '🔴 종료됨'}
-                  </span>
-                </div>
-                <div className="chat-room-message">
-                  {room.latestMessageContent || "새로운 채팅을 시작해보세요!"}
-                </div>
-                <div className="chat-room-footer">
-                  <span className="chat-room-author">
-                    {user?.userId === room.lostPostInfo.authorId 
-                      ? `채팅 요청자: ${room.participantUserName}`
-                      : `공고 작성자: ${room.lostPostInfo.author}`
-                    }
-                  </span>
-                  <span 
-                    className="post-link"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      navigate(`/lostAnimal/detail/${room.lostPostInfo.postId}`);
-                    }}
-                  >
-                    공고로 이동 &gt;
-                  </span>
-                </div>
-              </div>
-            </div>
-          ))
+            );
+          })
         )}
       </div>
     </div>

--- a/src/pages/chat/ChatRooms.jsx
+++ b/src/pages/chat/ChatRooms.jsx
@@ -1,0 +1,86 @@
+import React, { useEffect, useState, useContext } from 'react';
+import { useNavigate } from 'react-router-dom';
+import client from '../../api/client';
+import { AuthContext } from '../../contexts/AuthContext';
+import './ChatRooms.css';
+
+function ChatRooms() {
+  const [chatRooms, setChatRooms] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const navigate = useNavigate();
+  const { isLoggedIn } = useContext(AuthContext);
+
+  useEffect(() => {
+    if (!isLoggedIn) {
+      alert('로그인이 필요한 서비스입니다.');
+      navigate('/login');
+      return;
+    }
+
+    const fetchChatRooms = async () => {
+      try {
+        const response = await client.get('/chat/rooms');
+        setChatRooms(response.data.chatRoomsDetails);
+      } catch (error) {
+        console.error('채팅방 목록 조회 오류:', error);
+        setError('채팅방 목록을 불러오는데 실패했습니다.');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchChatRooms();
+  }, [isLoggedIn, navigate]);
+
+  const handleChatRoomClick = (chatRoomId) => {
+    navigate(`/chat/${chatRoomId}`);
+  };
+
+  if (loading) return <div className="chat-rooms-container">로딩 중...</div>;
+  if (error) return <div className="chat-rooms-container">{error}</div>;
+
+  return (
+    <div className="chat-rooms-container">
+      <h1>채팅 목록</h1>
+      <div className="chat-rooms-list">
+        {chatRooms.length === 0 ? (
+          <div className="no-chat-rooms">
+            진행 중인 채팅이 없습니다.
+          </div>
+        ) : (
+          chatRooms.map((room) => (
+            <div
+              key={room.chatRoomId}
+              className={`chat-room-item ${room.status === 'INACTIVE' ? 'inactive' : ''}`}
+              onClick={() => handleChatRoomClick(room.chatRoomId)}
+            >
+              <div className="chat-room-image">
+                <img src={room.lostPostInfo.imageUrl} alt="분실동물" />
+              </div>
+              <div className="chat-room-info">
+                <div className="chat-room-kind">{room.lostPostInfo.kindNm}</div>
+                <div className="chat-room-location">{room.lostPostInfo.location}</div>
+                <div className="chat-room-author">작성자: {room.lostPostInfo.author}</div>
+                {room.status === 'INACTIVE' && (
+                  <div className="chat-room-status">종료된 채팅</div>
+                )}
+                <div 
+                  className="post-link"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    navigate(`/lostAnimal/detail/${room.lostPostInfo.postId}`);
+                  }}
+                >
+                  공고로 이동 &gt;
+                </div>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default ChatRooms; 

--- a/src/pages/chat/ChatRooms.jsx
+++ b/src/pages/chat/ChatRooms.jsx
@@ -222,7 +222,7 @@ function ChatRooms() {
                       {postTypeLabel}
                     </span>
                     <span className={`chat-room-status ${room.status.toLowerCase()}`}>
-                      {room.status === 'ACTIVE' ? '🟢' : '🔴'}
+                      {room.status === 'ACTIVE' ? '' : '종료된 채팅'}
                     </span>
                   </div>
                   

--- a/src/pages/chat/ChatRooms.jsx
+++ b/src/pages/chat/ChatRooms.jsx
@@ -9,6 +9,7 @@ function ChatRooms() {
   const [chatRooms, setChatRooms] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [newMessageRooms, setNewMessageRooms] = useState(new Set());
   const navigate = useNavigate();
   const { isLoggedIn, user } = useContext(AuthContext);
   
@@ -111,6 +112,7 @@ function ChatRooms() {
                     : r
                 )
               );
+              setNewMessageRooms(prev => { const next = new Set(prev); next.add(roomId); return next; });
             }
           );
           
@@ -159,6 +161,11 @@ function ChatRooms() {
   }, []);
 
   const handleChatRoomClick = (chatRoomId) => {
+    setNewMessageRooms(prev => {
+      const next = new Set(prev);
+      next.delete(chatRoomId);
+      return next;
+    });
     navigate(`/chat/${chatRoomId}`);
   };
 
@@ -189,9 +196,13 @@ function ChatRooms() {
             return (
               <div
                 key={room.chatRoomId}
-                className={`chat-room-item ${room.status === 'INACTIVE' ? 'inactive' : ''}`}
+                className={[
+                  'chat-room-item',
+                  room.status === 'INACTIVE' ? 'inactive' : '',
+                  newMessageRooms.has(room.chatRoomId) ? 'new-message' : ''
+                ].join(' ')}
                 onClick={() => handleChatRoomClick(room.chatRoomId)}
-              >
+                >
                 <div className="chat-room-image">
                   <img src={room.lostPostInfo.imageUrl} alt="분실동물" />
                 </div>

--- a/src/pages/chat/ChatRooms.jsx
+++ b/src/pages/chat/ChatRooms.jsx
@@ -9,7 +9,7 @@ function ChatRooms() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const navigate = useNavigate();
-  const { isLoggedIn } = useContext(AuthContext);
+  const { isLoggedIn, user } = useContext(AuthContext);
 
   useEffect(() => {
     if (!isLoggedIn) {
@@ -70,7 +70,12 @@ function ChatRooms() {
                   {room.latestMessageContent || "새로운 채팅을 시작해보세요!"}
                 </div>
                 <div className="chat-room-footer">
-                  <span className="chat-room-author">공고 작성자: {room.lostPostInfo.author}</span>
+                  <span className="chat-room-author">
+                    {user?.userId === room.lostPostInfo.authorId 
+                      ? `채팅 요청자: ${room.participantUserName}`
+                      : `공고 작성자: ${room.lostPostInfo.author}`
+                    }
+                  </span>
                   <span 
                     className="post-link"
                     onClick={(e) => {

--- a/src/pages/chat/ChatRooms.jsx
+++ b/src/pages/chat/ChatRooms.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useContext, useRef } from 'react';
+import React, { useEffect, useState, useContext, useRef, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import client from '../../api/client';
 import { AuthContext } from '../../contexts/AuthContext';
@@ -162,6 +162,14 @@ function ChatRooms() {
     navigate(`/chat/${chatRoomId}`);
   };
 
+  const sortedRooms = useMemo(() => {
+    return [...chatRooms].sort((a, b) => {
+      if (a.status === b.status) return 0;
+      // a가 INACTIVE 면 뒤로, 아니면 앞으로
+      return a.status === 'INACTIVE' ? 1 : -1;
+    });
+  }, [chatRooms]);
+
   if (loading) return <div className="chat-rooms-container">로딩 중...</div>;
   if (error) return <div className="chat-rooms-container">{error}</div>;
 
@@ -169,12 +177,12 @@ function ChatRooms() {
     <div className="chat-rooms-container">
       <h1>채팅 목록</h1>
       <div className="chat-rooms-list">
-        {chatRooms.length === 0 ? (
+      {sortedRooms.length === 0 ? (
           <div className="no-chat-rooms">
             진행 중인 채팅이 없습니다.
           </div>
         ) : (
-          chatRooms.map((room) => {
+          sortedRooms.map(room => {
             const isAuthor = user?.userId === room.lostPostInfo.authorId;
             const postTypeLabel = room.lostPostInfo.postType === 'LOST' ? '실종' : '발견';
             
@@ -217,7 +225,7 @@ function ChatRooms() {
                     <span className="chat-room-author">
                       {isAuthor
                         ? `${room.participantUserName}님`
-                        : room.lostPostInfo.location
+                        : `📍 ${room.lostPostInfo.location}`
                       }
                     </span>
                     <span

--- a/src/pages/chat/ChatRoomsByPost.css
+++ b/src/pages/chat/ChatRoomsByPost.css
@@ -1,0 +1,64 @@
+.chat-rooms-container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+.chat-rooms-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.chat-room-item {
+  display: flex;
+  padding: 16px;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  background-color: white;
+}
+
+.chat-room-item:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.chat-room-image {
+  width: 100px;
+  height: 100px;
+  margin-right: 16px;
+  flex-shrink: 0;
+}
+
+.chat-room-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 8px;
+}
+
+.chat-room-info {
+  flex: 1;
+}
+
+.chat-room-info h3 {
+  margin: 0 0 8px 0;
+  font-size: 18px;
+  color: #333;
+}
+
+.chat-room-info p {
+  margin: 4px 0;
+  color: #666;
+}
+
+.chat-room-info .kind {
+  font-weight: 500;
+  color: #FF8A3D;
+}
+
+.chat-room-info .location {
+  font-size: 14px;
+} 

--- a/src/pages/chat/ChatRoomsByPost.css
+++ b/src/pages/chat/ChatRoomsByPost.css
@@ -4,6 +4,12 @@
   padding: 20px;
 }
 
+.chat-rooms-container h2 {
+  text-align: center;
+  margin-bottom: 30px;
+  color: #333;
+}
+
 .chat-rooms-list {
   display: flex;
   flex-direction: column;
@@ -41,24 +47,76 @@
 
 .chat-room-info {
   flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 }
 
-.chat-room-info h3 {
-  margin: 0 0 8px 0;
-  font-size: 18px;
+.chat-room-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.participant-name {
+  font-size: 16px;
+  font-weight: 600;
   color: #333;
 }
 
-.chat-room-info p {
-  margin: 4px 0;
-  color: #666;
-}
-
-.chat-room-info .kind {
-  font-weight: 500;
-  color: #FF8A3D;
-}
-
-.chat-room-info .location {
+.chat-room-status {
   font-size: 14px;
+}
+
+.chat-room-status.active {
+  color: #2ea043;
+}
+
+.chat-room-status.inactive {
+  color: #ff4444;
+}
+
+.chat-room-message {
+  color: #666;
+  font-size: 15px;
+  margin: 8px 0;
+  flex: 1;
+}
+
+.chat-room-footer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.chat-room-kind {
+  color: #FF8A3D;
+  font-weight: 500;
+  font-size: 14px;
+}
+
+.divider {
+  color: #e0e0e0;
+  font-size: 14px;
+}
+
+.chat-room-location {
+  color: #666;
+  font-size: 14px;
+}
+
+.no-chat-rooms {
+  text-align: center;
+  padding: 40px;
+  color: #666;
+  font-size: 16px;
+  background-color: #f5f5f5;
+  border-radius: 8px;
+}
+
+.inactive {
+  opacity: 0.7;
+  background-color: #f5f5f5;
 } 

--- a/src/pages/chat/ChatRoomsByPost.css
+++ b/src/pages/chat/ChatRoomsByPost.css
@@ -26,6 +26,12 @@
   background-color: white;
 }
 
+/* 새 메시지 도착 강조 */
+.chat-room-item.new-message {
+  border-color: #3B82F6;  /* 파란색 */
+  box-shadow: 0 0 8px rgba(59, 130, 246, 0.5);
+}
+
 .chat-room-item:hover {
   transform: translateY(-2px);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);

--- a/src/pages/chat/ChatRoomsByPost.jsx
+++ b/src/pages/chat/ChatRoomsByPost.jsx
@@ -39,29 +39,46 @@ function ChatRoomsByPost() {
     <div className="chat-rooms-container">
       <h2>채팅방 목록</h2>
       <div className="chat-rooms-list">
-        {chatRooms.map((room) => (
-          <div
-            key={room.chatRoomId}
-            className="chat-room-item"
-            onClick={() => handleChatRoomClick(room.chatRoomId)}
-          >
-            <div className="chat-room-image">
-              <img 
-                src={room.lostPostInfo.imageUrl} 
-                alt={`${room.lostPostInfo.kindNm}`}
-                onError={(e) => {
-                  e.target.onerror = null;
-                  e.target.src = '/default-image.jpg'; // 기본 이미지로 대체
-                }}
-              />
-            </div>
-            <div className="chat-room-info">
-              <h3>{room.participantUserName}</h3>
-              <p className="kind">{room.lostPostInfo.kindNm}</p>
-              <p className="location">{room.lostPostInfo.location}</p>
-            </div>
+        {chatRooms.length === 0 ? (
+          <div className="no-chat-rooms">
+            요청된 채팅이 없습니다.
           </div>
-        ))}
+        ) : (
+          chatRooms.map((room) => (
+            <div
+              key={room.chatRoomId}
+              className={`chat-room-item ${room.status === 'INACTIVE' ? 'inactive' : ''}`}
+              onClick={() => handleChatRoomClick(room.chatRoomId)}
+            >
+              <div className="chat-room-image">
+                <img 
+                  src={room.lostPostInfo.imageUrl} 
+                  alt={`${room.lostPostInfo.kindNm}`}
+                  onError={(e) => {
+                    e.target.onerror = null;
+                    e.target.src = '/default-image.jpg';
+                  }}
+                />
+              </div>
+              <div className="chat-room-info">
+                <div className="chat-room-header">
+                  <span className="participant-name">{room.participantUserName}</span>
+                  <span className={`chat-room-status ${room.status.toLowerCase()}`}>
+                    {room.status === 'ACTIVE' ? '🟢 진행중' : '🔴 종료됨'}
+                  </span>
+                </div>
+                <div className="chat-room-message">
+                  {room.latestMessageContent || "새로운 채팅을 시작해보세요!"}
+                </div>
+                <div className="chat-room-footer">
+                  <span className="chat-room-kind">{room.lostPostInfo.kindNm}</span>
+                  <span className="divider">|</span>
+                  <span className="chat-room-location">{room.lostPostInfo.location}</span>
+                </div>
+              </div>
+            </div>
+          ))
+        )}
       </div>
     </div>
   );

--- a/src/pages/chat/ChatRoomsByPost.jsx
+++ b/src/pages/chat/ChatRoomsByPost.jsx
@@ -13,7 +13,9 @@ function ChatRoomsByPost() {
   useEffect(() => {
     const fetchChatRooms = async () => {
       try {
-        const response = await client.get(`chat/rooms/post/${postId}`);
+        const response = await client.get('chat/rooms', {
+          params: { postId }
+        });
         if (response.data && response.data.chatRoomsDetails) {
           setChatRooms(response.data.chatRoomsDetails);
         }

--- a/src/pages/chat/ChatRoomsByPost.jsx
+++ b/src/pages/chat/ChatRoomsByPost.jsx
@@ -157,7 +157,7 @@ function ChatRoomsByPost() {
                 <div className="chat-room-header">
                   <span className="participant-name">{room.participantUserName}</span>
                   <span className={`chat-room-status ${room.status.toLowerCase()}`}>
-                    {room.status === 'ACTIVE' ? '🟢' : '🔴'}
+                    {room.status === 'ACTIVE' ? '' : '종료된 채팅'}
                   </span>
                 </div>
                 <div className="chat-room-message">

--- a/src/pages/chat/ChatRoomsByPost.jsx
+++ b/src/pages/chat/ChatRoomsByPost.jsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import client from '../../api/client';
+import './ChatRoomsByPost.css';
+
+function ChatRoomsByPost() {
+  const { postId } = useParams();
+  const navigate = useNavigate();
+  const [chatRooms, setChatRooms] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchChatRooms = async () => {
+      try {
+        const response = await client.get(`chat/rooms/post/${postId}`);
+        if (response.data && response.data.chatRoomsDetails) {
+          setChatRooms(response.data.chatRoomsDetails);
+        }
+      } catch (error) {
+        console.error('채팅방 목록 조회 실패:', error);
+        setError('채팅방 목록을 불러오는데 실패했습니다.');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchChatRooms();
+  }, [postId]);
+
+  const handleChatRoomClick = (chatRoomId) => {
+    navigate(`/chat/${chatRoomId}`);
+  };
+
+  if (loading) return <div className="chat-rooms-container">로딩 중...</div>;
+  if (error) return <div className="chat-rooms-container">{error}</div>;
+
+  return (
+    <div className="chat-rooms-container">
+      <h2>채팅방 목록</h2>
+      <div className="chat-rooms-list">
+        {chatRooms.map((room) => (
+          <div
+            key={room.chatRoomId}
+            className="chat-room-item"
+            onClick={() => handleChatRoomClick(room.chatRoomId)}
+          >
+            <div className="chat-room-image">
+              <img 
+                src={room.lostPostInfo.imageUrl} 
+                alt={`${room.lostPostInfo.kindNm}`}
+                onError={(e) => {
+                  e.target.onerror = null;
+                  e.target.src = '/default-image.jpg'; // 기본 이미지로 대체
+                }}
+              />
+            </div>
+            <div className="chat-room-info">
+              <h3>{room.participantUserName}</h3>
+              <p className="kind">{room.lostPostInfo.kindNm}</p>
+              <p className="location">{room.lostPostInfo.location}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default ChatRoomsByPost; 

--- a/src/pages/chat/ChatRoomsByPost.jsx
+++ b/src/pages/chat/ChatRoomsByPost.jsx
@@ -13,6 +13,7 @@ function ChatRoomsByPost() {
   const [chatRooms, setChatRooms] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [newMessageRooms, setNewMessageRooms] = useState(new Set());
 
   // 구독 추적용 refs
   const subscribedRoomsRef = useRef(new Set());
@@ -100,6 +101,11 @@ function ChatRoomsByPost() {
                 : r
             )
           );
+          setNewMessageRooms(prev => {
+            const next = new Set(prev);
+            next.add(roomId);
+            return next;
+          });
         });
         subscribedRoomsRef.current.add(roomId);
       }
@@ -107,6 +113,11 @@ function ChatRoomsByPost() {
   }, [chatRooms]);
 
   const handleChatRoomClick = (chatRoomId) => {
+    setNewMessageRooms(prev => {
+      const next = new Set(prev);
+      next.delete(chatRoomId);
+      return next;
+    });
     navigate(`/chat/${chatRoomId}`);
   };
 
@@ -124,9 +135,13 @@ function ChatRoomsByPost() {
         ) : (
           chatRooms.map(room => (
             <div
-              key={room.chatRoomId}
-              className={`chat-room-item ${room.status === 'INACTIVE' ? 'inactive' : ''}`}
-              onClick={() => handleChatRoomClick(room.chatRoomId)}
+            key={room.chatRoomId}
+            className={[
+              'chat-room-item',
+              room.status === 'INACTIVE' ? 'inactive' : '',
+              newMessageRooms.has(room.chatRoomId) ? 'new-message' : ''
+            ].join(' ')}
+            onClick={() => handleChatRoomClick(room.chatRoomId)}
             >
               <div className="chat-room-image">
                 <img 

--- a/src/pages/chat/ChatRoomsByPost.jsx
+++ b/src/pages/chat/ChatRoomsByPost.jsx
@@ -1,41 +1,117 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef, useContext } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import client from '../../api/client';
+import WebSocketService from '../../services/WebSocketService';
+import { AuthContext } from '../../contexts/AuthContext';
 import './ChatRoomsByPost.css';
 
 function ChatRoomsByPost() {
   const { postId } = useParams();
   const navigate = useNavigate();
+  const { isLoggedIn } = useContext(AuthContext);
+
   const [chatRooms, setChatRooms] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
+  // 구독 추적용 refs
+  const subscribedRoomsRef = useRef(new Set());
+  const isWebSocketConnectedRef = useRef(false);
+
+  // 1) 서버에서 방 목록 불러오기
   useEffect(() => {
+    if (!isLoggedIn) {
+      navigate('/login');
+      return;
+    }
+
     const fetchChatRooms = async () => {
+      setLoading(true);
       try {
-        const response = await client.get('chat/rooms', {
-          params: { postId }
-        });
-        if (response.data && response.data.chatRoomsDetails) {
-          setChatRooms(response.data.chatRoomsDetails);
-        }
-      } catch (error) {
-        console.error('채팅방 목록 조회 실패:', error);
+        const response = await client.get('/chat/rooms', { params: { postId } });
+        setChatRooms(response.data.chatRoomsDetails || []);
+      } catch (e) {
+        console.error('채팅방 목록 조회 실패:', e);
         setError('채팅방 목록을 불러오는데 실패했습니다.');
       } finally {
         setLoading(false);
       }
     };
-
     fetchChatRooms();
-  }, [postId]);
+  }, [postId, isLoggedIn, navigate]);
+
+  // 2) 최초 마운트 시 WebSocket 연결, 언마운트 시 정리
+  useEffect(() => {
+    if (!isLoggedIn) return;
+
+    const connect = async () => {
+      if (!isWebSocketConnectedRef.current) {
+        try {
+          await WebSocketService.connect();
+          isWebSocketConnectedRef.current = true;
+          console.log('[ByPost] WebSocket connected');
+        } catch (e) {
+          console.error('[ByPost] WebSocket 연결 실패:', e);
+        }
+      }
+    };
+    connect();
+
+    return () => {
+      // 모든 구독 해지
+      subscribedRoomsRef.current.forEach(roomId => {
+        WebSocketService.unsubscribe(`/user/queue/chat/${roomId}`);
+      });
+      subscribedRoomsRef.current.clear();
+      // 연결 해제
+      WebSocketService.disconnect();
+      isWebSocketConnectedRef.current = false;
+    };
+  }, [isLoggedIn]);
+
+  // 3) chatRooms 변경 시 ACTIVE 방들 구독 / 해지
+  useEffect(() => {
+    if (!isWebSocketConnectedRef.current || chatRooms.length === 0) return;
+
+    const activeRoomIds = new Set(
+      chatRooms
+        .filter(r => r.status === 'ACTIVE')
+        .map(r => r.chatRoomId)
+    );
+
+    // 3-1) 더 이상 ACTIVE가 아닌 방 구독 해지
+    subscribedRoomsRef.current.forEach(roomId => {
+      if (!activeRoomIds.has(roomId)) {
+        WebSocketService.unsubscribe(`/user/queue/chat/${roomId}`);
+        subscribedRoomsRef.current.delete(roomId);
+      }
+    });
+
+    // 3-2) 새로운 ACTIVE 방 구독
+    activeRoomIds.forEach(roomId => {
+      if (!subscribedRoomsRef.current.has(roomId)) {
+        const dest = `/user/queue/chat/${roomId}`;
+        WebSocketService.subscribe(dest, message => {
+          const payload = JSON.parse(message.body);
+          setChatRooms(prev =>
+            prev.map(r =>
+              r.chatRoomId === roomId
+                ? { ...r, latestMessageContent: payload.content }
+                : r
+            )
+          );
+        });
+        subscribedRoomsRef.current.add(roomId);
+      }
+    });
+  }, [chatRooms]);
 
   const handleChatRoomClick = (chatRoomId) => {
     navigate(`/chat/${chatRoomId}`);
   };
 
   if (loading) return <div className="chat-rooms-container">로딩 중...</div>;
-  if (error) return <div className="chat-rooms-container">{error}</div>;
+  if (error)   return <div className="chat-rooms-container">{error}</div>;
 
   return (
     <div className="chat-rooms-container">
@@ -46,7 +122,7 @@ function ChatRoomsByPost() {
             요청된 채팅이 없습니다.
           </div>
         ) : (
-          chatRooms.map((room) => (
+          chatRooms.map(room => (
             <div
               key={room.chatRoomId}
               className={`chat-room-item ${room.status === 'INACTIVE' ? 'inactive' : ''}`}
@@ -55,8 +131,8 @@ function ChatRoomsByPost() {
               <div className="chat-room-image">
                 <img 
                   src={room.lostPostInfo.imageUrl} 
-                  alt={`${room.lostPostInfo.kindNm}`}
-                  onError={(e) => {
+                  alt={room.lostPostInfo.kindNm}
+                  onError={e => {
                     e.target.onerror = null;
                     e.target.src = '/default-image.jpg';
                   }}
@@ -66,7 +142,7 @@ function ChatRoomsByPost() {
                 <div className="chat-room-header">
                   <span className="participant-name">{room.participantUserName}</span>
                   <span className={`chat-room-status ${room.status.toLowerCase()}`}>
-                    {room.status === 'ACTIVE' ? '🟢 진행중' : '🔴 종료됨'}
+                    {room.status === 'ACTIVE' ? '🟢' : '🔴'}
                   </span>
                 </div>
                 <div className="chat-room-message">
@@ -86,4 +162,4 @@ function ChatRoomsByPost() {
   );
 }
 
-export default ChatRoomsByPost; 
+export default ChatRoomsByPost;

--- a/src/pages/lostanimal/LostAnimalDetail.jsx
+++ b/src/pages/lostanimal/LostAnimalDetail.jsx
@@ -166,13 +166,6 @@ function LostAnimalDetail() {
   if (loading) return <div className="lost-animal-container">로딩 중...</div>;
   if (error || !data) return <div className="lost-animal-container">{error || '데이터 없음'}</div>;
 
-  // 디버깅을 위한 로그 추가
-  console.log('전체 유저 정보:', user);
-  console.log('로그인 상태:', isLoggedIn);
-  console.log('현재 로그인한 사용자 ID:', user?.userId);
-  console.log('게시글 작성자 ID:', data.authorId);  
-  console.log('조건부 렌더링 결과:', isLoggedIn && user?.userId === data.authorId);
-
   // 데이터 구조 확인을 위한 로깅
   const {
     lostPostId,

--- a/src/pages/lostanimal/LostAnimalDetail.jsx
+++ b/src/pages/lostanimal/LostAnimalDetail.jsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useState, useRef } from "react";
+import React, { useEffect, useState, useRef, useContext } from "react";
 import { useParams, useLocation } from "react-router-dom";
 import client from "../../api/client";
 import userImage from '../../assets/images/user.jpg';
 import "./LostAnimal.css";
+import { AuthContext } from "../../contexts/AuthContext";
 
 function LostAnimalDetail() {
   const { id } = useParams();
@@ -12,6 +13,7 @@ function LostAnimalDetail() {
   const [data, setData] = useState(null);
   const mapRef = useRef(null);
   const mapContainerRef = useRef(null);
+  const { user, isLoggedIn } = useContext(AuthContext);
 
   // 카카오맵 SDK 로드
   useEffect(() => {
@@ -122,11 +124,44 @@ function LostAnimalDetail() {
     fetchData();
   }, [id, currentLocation.state]);
 
+  // 채팅 버튼 클릭 핸들러
+  const handleChatButtonClick = async () => {
+    if (!data || !isLoggedIn) {
+      alert('로그인이 필요한 서비스입니다.');
+      return;
+    }
+
+    const requestData = {
+      postId: Number(data.lostPostId),
+      authorId: Number(data.authorId)
+    };
+    
+    try {
+      const response = await client.post('/chat/rooms', requestData);
+      
+      if (response && response.data && response.data.chatRoomId) {
+        // 성공 시 채팅방으로 리다이렉트
+        window.location.href = `/chat/${response.data.chatRoomId}`;
+      }
+    } catch (error) {
+      console.error('채팅방 생성 오류:', error);
+      
+      if (error.status === 401 || error.status === 403) {
+        alert('로그인이 필요하거나 권한이 없습니다.');
+      } else if (error.code === 'CHATROOM_POST_ERROR') {
+        alert('채팅방을 생성할 수 없습니다');
+      } else {
+        alert('채팅방 생성 중 오류가 발생했습니다.');
+      }
+    }
+  };
+
   if (loading) return <div className="lost-animal-container">로딩 중...</div>;
   if (error || !data) return <div className="lost-animal-container">{error || '데이터 없음'}</div>;
 
   // 데이터 구조 확인을 위한 로깅
   const {
+    lostPostId,
     date,
     upKindNm,
     kindNm,
@@ -139,6 +174,7 @@ function LostAnimalDetail() {
     rfidCd,
     location,
     author,
+    authorId,
     createdAt
   } = data;
 
@@ -235,6 +271,25 @@ function LostAnimalDetail() {
           </tr>
         </tbody>
       </table>
+      
+      {/* 채팅하기 버튼 */}
+      <div style={{ textAlign: 'center', marginTop: 20, marginBottom: 20 }}>
+        <button 
+          onClick={handleChatButtonClick}
+          style={{
+            backgroundColor: '#FF8A3D',
+            color: 'white',
+            border: 'none',
+            borderRadius: '5px',
+            padding: '12px 24px',
+            fontSize: '16px',
+            fontWeight: 'bold',
+            cursor: 'pointer'
+          }}
+        >
+          채팅하기
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/pages/lostanimal/LostAnimalDetail.jsx
+++ b/src/pages/lostanimal/LostAnimalDetail.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useRef, useContext } from "react";
-import { useParams, useLocation } from "react-router-dom";
+import { useParams, useLocation, useNavigate } from "react-router-dom";
 import client from "../../api/client";
 import userImage from '../../assets/images/user.jpg';
 import "./LostAnimal.css";
@@ -14,6 +14,7 @@ function LostAnimalDetail() {
   const mapRef = useRef(null);
   const mapContainerRef = useRef(null);
   const { user, isLoggedIn } = useContext(AuthContext);
+  const navigate = useNavigate();
 
   // 카카오맵 SDK 로드
   useEffect(() => {
@@ -131,6 +132,13 @@ function LostAnimalDetail() {
       return;
     }
 
+    // 작성자인 경우 채팅방 목록 페이지로 이동
+    if (isLoggedIn && user?.userId === data.authorId) {
+      navigate(`/chatrooms/post/${data.lostPostId}`);
+      return;
+    }
+
+    // 작성자가 아닌 경우 기존 로직 실행
     const requestData = {
       postId: Number(data.lostPostId),
       authorId: Number(data.authorId)
@@ -140,7 +148,6 @@ function LostAnimalDetail() {
       const response = await client.post('/chat/rooms', requestData);
       
       if (response && response.data && response.data.chatRoomId) {
-        // 성공 시 채팅방으로 리다이렉트
         window.location.href = `/chat/${response.data.chatRoomId}`;
       }
     } catch (error) {
@@ -158,6 +165,13 @@ function LostAnimalDetail() {
 
   if (loading) return <div className="lost-animal-container">로딩 중...</div>;
   if (error || !data) return <div className="lost-animal-container">{error || '데이터 없음'}</div>;
+
+  // 디버깅을 위한 로그 추가
+  console.log('전체 유저 정보:', user);
+  console.log('로그인 상태:', isLoggedIn);
+  console.log('현재 로그인한 사용자 ID:', user?.userId);
+  console.log('게시글 작성자 ID:', data.authorId);  
+  console.log('조건부 렌더링 결과:', isLoggedIn && user?.userId === data.authorId);
 
   // 데이터 구조 확인을 위한 로깅
   const {
@@ -269,26 +283,44 @@ function LostAnimalDetail() {
             <td style={{ fontWeight: 600, padding: 12 }}>추가설명</td>
             <td colSpan={3} style={{ padding: 12 }}>{content || '-'}</td>
           </tr>
-        </tbody>
-      </table>
+          </tbody>
+        </table>
       
       {/* 채팅하기 버튼 */}
       <div style={{ textAlign: 'center', marginTop: 20, marginBottom: 20 }}>
-        <button 
-          onClick={handleChatButtonClick}
-          style={{
-            backgroundColor: '#FF8A3D',
-            color: 'white',
-            border: 'none',
-            borderRadius: '5px',
-            padding: '12px 24px',
-            fontSize: '16px',
-            fontWeight: 'bold',
-            cursor: 'pointer'
-          }}
-        >
-          채팅하기
-        </button>
+        {isLoggedIn && user?.userId === data.authorId ? (
+          <button 
+            onClick={handleChatButtonClick}
+            style={{
+              backgroundColor: '#4CAF50',
+              color: 'white',
+              border: 'none',
+              borderRadius: '5px',
+              padding: '12px 24px',
+              fontSize: '16px',
+              fontWeight: 'bold',
+              cursor: 'pointer'
+            }}
+          >
+            요청된 채팅으로 이동
+          </button>
+        ) : (
+          <button 
+            onClick={handleChatButtonClick}
+            style={{
+              backgroundColor: '#FF8A3D',
+              color: 'white',
+              border: 'none',
+              borderRadius: '5px',
+              padding: '12px 24px',
+              fontSize: '16px',
+              fontWeight: 'bold',
+              cursor: 'pointer'
+            }}
+          >
+            채팅하기
+          </button>
+        )}
       </div>
     </div>
   );

--- a/src/services/WebSocketService.js
+++ b/src/services/WebSocketService.js
@@ -139,6 +139,11 @@ class WebSocketService {
     }
   }
 
+    // 연결 여부 확인
+    isConnected() {
+      return this.stompClient && this.connected;
+    }
+  
   // 웹소켓 메시지 전송
   send(destination, body) {
     if (!this.connected) {


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 페이지 구현
- [x] API 연동
- [ ] 버그 수정
- [ ] UI/UX 개선
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feature/#22 -> develop

### 변경 사항
- 실종 공고에서 채팅방 생성 버튼을 구현했습니다. 사용자가 해당 공고의 작성자인 경우에는 '요청된 채팅방 목록'으로 변경됩니다.
- 헤더에 채팅 목록 항목을 추가하고, 채팅 목록 화면을 추가했습니다.
- 각 항목 클릭시 해당 채팅방으로 navigate됩니다.
- 채팅 목록에서 실시간으로 채팅을 받아오고, 새 채팅이 온 경우 테두리 색상 효과를 주었습니다.

### PR 체크리스트
- [x] 디자인이랑 일치하나요?
- [x] 빌드는 성공했나요?
- [ ] 코드 포맷팅을 진행했나요?
- [ ] 컴포넌트의 재사용성을 고려했나요?
- [ ] 반응형 디자인을 적용했나요?

### 스크린샷
- 유저의 전체 채팅방 목록
<img width="903" alt="image" src="https://github.com/user-attachments/assets/1b2bba80-9f4a-4b1b-9e72-bff59ed07c2a" />

- 본인이 실종 공고의 author인 경우, '요청된 채팅방으로 이동'
<img width="924" alt="image" src="https://github.com/user-attachments/assets/387a6998-09e6-4315-8cca-22b6b7a23887" />

- 요청된 채팅방으로 이동
<img width="911" alt="image" src="https://github.com/user-attachments/assets/a0bf46e2-dfb6-4451-809a-4a406eee8915" />


- 본인이 실종 공고의 author가 아닌 경우, '채팅하기'
<img width="908" alt="image" src="https://github.com/user-attachments/assets/b5f3c144-326b-49ee-8b53-9021ff2d995b" />

- 실시간으로 채팅방으로 메시지가 온 경우
<img width="910" alt="image" src="https://github.com/user-attachments/assets/73914e45-a5dc-4bd9-b3f3-f21906bfdf68" />

- ACTIVE인 채팅방들로만 구독
<img width="582" alt="image" src="https://github.com/user-attachments/assets/26de1fe0-dafb-411a-9b49-39b46626d3bf" />



### 추가 설명
- 백엔드 [PW-49]와 함께 실행하시면 됩니다.
- 추후 UI 개선 하겠습니다!
- 추후 작업에 채팅방 비활성화 기능 추가 하겠습니다.
- 추후 작업에 사용자가 허가되지 않은 채팅방으로 직접 접속 시도시 차단하는 기능 추가 하겠습니다.