### PR TITLE
[PW-53] 배포 스크립트에 도커 이미지 최적화

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - feature/#53
 
 jobs:
   build-and-deploy:
@@ -28,16 +29,13 @@ jobs:
           echo "${{ secrets.SERVICE_WORKER_FIREBASE_CONFIG }}" | base64 --decode > ./public/firebaseConfig.js
         shell: bash
 
-      - name: Build Docker image
+      - name: Build & Tag Docker image
         run: |
           docker build -t pawong/frontend:latest .
-
-      - name: Push Docker image
-        run: |
           docker push pawong/frontend:latest
 
       - name: Deploy to remote server
-        uses: appleboy/ssh-action@v0.1.6
+        uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.DEPLOY_HOST }}
           username: ubuntu
@@ -45,6 +43,10 @@ jobs:
           script: |
             cd /home/ubuntu/deploy
             sudo docker compose stop frontend
-            sudo docker rmi pawong/frontend:latest || true
             sudo docker pull pawong/frontend:latest
-            sudo docker compose up -d --no-deps --build frontend
+
+            # dangling 이미지들 한번에 제거
+            sudo docker image prune -f
+
+            # --no-build 추가해 로컬 빌드 안하고, pull한 이미지로 서비스 실행
+            sudo docker compose up -d --no-deps --no-build frontend

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - develop
-      - feature/#53
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -43,9 +43,9 @@ jobs:
             cd /home/ubuntu/deploy
             sudo docker compose stop frontend
             sudo docker pull pawong/frontend:latest
+            
+            # --no-build 추가해 로컬 빌드 안하고, pull한 이미지로 서비스 실행
+            sudo docker compose up -d --no-deps --no-build frontend
 
             # dangling 이미지들 한번에 제거
             sudo docker image prune -f
-
-            # --no-build 추가해 로컬 빌드 안하고, pull한 이미지로 서비스 실행
-            sudo docker compose up -d --no-deps --no-build frontend


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 페이지 구현
- [ ] API 연동
- [ ] 버그 수정
- [ ] UI/UX 개선
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feature/#53 -> develop

### 변경 사항
- 도커 이미지가 서버에 계속 쌓이는 문제를 해결했습니다.
- appleboy/ssh-action 버전을 기존 v0.1.6에서 v1.x.x 버전대로 바꿨습니다. 

### PR 체크리스트
- [ ] 디자인이랑 일치하나요?
- [ ] 빌드는 성공했나요?
- [ ] 코드 포맷팅을 진행했나요?
- [ ] 컴포넌트의 재사용성을 고려했나요?
- [ ] 반응형 디자인을 적용했나요?

### 스크린샷


### 추가 설명
배포 스크립트에 의해 새 프론트엔드 이미지를 :latest 태그로 붙여 dockerhub에 올린 후 그걸 서버에서 받아오면, 기존 프론트엔드 이미지는 latest 태그를 잃고 dangling 상태가 됩니다. 근데 기존 배포 스크립트에서는 `docker rmi pawong/frontend:latest || true`를 실행하니, 정작 없어져야 할 dangling 상태의 이미지가 삭제되지 않았습니다. 🙀 확인 감사합니다.