### PR TITLE
[PW-61] 채팅방 헤더 구현 및 이중스크롤 제거, 마이페이지 찜 목록 화살표 변경

### DIFF
--- a/src/assets/images/icons/arrow-left.svg
+++ b/src/assets/images/icons/arrow-left.svg
@@ -1,4 +1,4 @@
 <svg width="50" height="50" viewBox="0 0 50 50" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <circle cx="25" cy="25" r="25" fill="#666666" />
-  <path d="M30 15L20 25L30 35" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="25" cy="25" r="24" fill="white" stroke="#3581B8" stroke-width="2"/>
+  <path d="M30 15L20 25L30 35" stroke="#3581B8" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
 </svg> 

--- a/src/assets/images/icons/arrow-right.svg
+++ b/src/assets/images/icons/arrow-right.svg
@@ -1,4 +1,4 @@
 <svg width="50" height="50" viewBox="0 0 50 50" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <circle cx="25" cy="25" r="25" fill="#666666" />
-  <path d="M20 15L30 25L20 35" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="25" cy="25" r="24" fill="white" stroke="#3581B8" stroke-width="2"/>
+  <path d="M20 15L30 25L20 35" stroke="#3581B8" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
 </svg> 

--- a/src/assets/images/icons/back-arrow.svg
+++ b/src/assets/images/icons/back-arrow.svg
@@ -1,3 +1,3 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M15 18L9 12L15 6" stroke="#3581B8" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M15 18L9 12L15 6" stroke="#F86A60" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
 </svg> 

--- a/src/assets/images/icons/back-arrow.svg
+++ b/src/assets/images/icons/back-arrow.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M15 18L9 12L15 6" stroke="#3581B8" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg> 

--- a/src/assets/images/icons/kebab-menu.svg
+++ b/src/assets/images/icons/kebab-menu.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="12" cy="6" r="2" fill="#333333"/>
+  <circle cx="12" cy="12" r="2" fill="#333333"/>
+  <circle cx="12" cy="18" r="2" fill="#333333"/>
+</svg> 

--- a/src/components/chat/ChatRoom.jsx
+++ b/src/components/chat/ChatRoom.jsx
@@ -26,6 +26,7 @@ const ChatRoom = () => {
   const [chatRoomInfo, setChatRoomInfo] = useState(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
+  const [isWelcomeModalOpen, setIsWelcomeModalOpen] = useState(false);
 
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -40,6 +41,11 @@ const ChatRoom = () => {
         const chatRoomDetail = chatRoomResponse.data.chatRoomDetail;
         setChatRoomInfo(chatRoomDetail);
         setIsChatActive(chatRoomDetail.status === 'ACTIVE');
+
+        // 첫 접속 시 모달 표시
+        if (chatRoomDetail.latestMessageContent === "") {
+          setIsWelcomeModalOpen(true);
+        }
 
         // 게시글 정보 조회
         const postResponse = await client.get(`/lost-animals/lost-posts/${id}`);
@@ -380,6 +386,25 @@ const ChatRoom = () => {
                   아니요
                 </button>
               </div>
+            </div>
+          </div>
+        )}
+
+        {/* 환영 모달 */}
+        {isWelcomeModalOpen && (
+          <div className={styles.modalOverlay} onClick={() => setIsWelcomeModalOpen(false)}>
+            <div className={`${styles.modal} ${styles.welcomeModal}`} onClick={e => e.stopPropagation()}>
+              <div className={styles.welcomeContent}>
+                <p>💬 자유롭게 채팅을 시작하세요! 언제든 준비될 때 메시지를 보내보세요.</p>
+                <p>🐾 반려동물이 주인을 잘 찾아갈 수 있도록 기여하는 여러분이 있어 세상이 한층 아름다워집니다.</p>
+                <p>🚫 모종의 이유로 공고가 마감되거나 더 이상 채팅을 진행할 의향이 없는 경우, 채팅방을 비활성화 할 수 있습니다.</p>
+              </div>
+              <button 
+                className={styles.welcomeCloseButton}
+                onClick={() => setIsWelcomeModalOpen(false)}
+              >
+                닫기
+              </button>
             </div>
           </div>
         )}

--- a/src/components/chat/ChatRoom.jsx
+++ b/src/components/chat/ChatRoom.jsx
@@ -5,6 +5,8 @@ import { AuthContext } from '../../contexts/AuthContext';
 import styles from './ChatRoom.module.css';
 import client from '../../api/client';
 import userImage from '../../assets/images/user.jpg';
+import backArrow from '../../assets/images/icons/back-arrow.svg';
+import kebabMenu from '../../assets/images/icons/kebab-menu.svg';
 
 function formatDateWithDay(date) {
   const d = new Date(Number(date));
@@ -22,6 +24,8 @@ const ChatRoom = () => {
   const [animalData, setAnimalData] = useState(null);
   const [isChatActive, setIsChatActive] = useState(true);
   const [chatRoomInfo, setChatRoomInfo] = useState(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
 
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -191,6 +195,29 @@ const ChatRoom = () => {
     }
   };
 
+  const handleDeactivateChat = async () => {
+    if (!isChatActive) {
+      alert("이미 비활성화된 채팅입니다!");
+      setIsModalOpen(false);
+      return;
+    }
+
+    setIsConfirmModalOpen(true);
+  };
+
+  const confirmDeactivation = async () => {
+    try {
+      await client.patch(`/chat/rooms/${roomId}`);
+      alert("채팅방이 비활성화 됐습니다!");
+      setIsChatActive(false);
+    } catch (error) {
+      console.error('채팅방 비활성화 실패:', error);
+      alert('채팅방 비활성화에 실패했습니다.');
+    }
+    setIsConfirmModalOpen(false);
+    setIsModalOpen(false);
+  };
+
   const renderMessage = (message) => {
     const isMyMessage = Number(message.senderId) === Number(user?.userId);
     const messageDate = new Date(Number(message.createdAt));
@@ -277,6 +304,12 @@ const ChatRoom = () => {
       <div className={styles.chatRoom}>
         <div className={styles.chatHeader}>
           <img
+            src={backArrow}
+            alt="뒤로 가기"
+            className={styles.backButton}
+            onClick={() => navigate('/chatrooms')}
+          />
+          <img
             src={animalData?.imageUrl || userImage}
             alt="공고 이미지"
             className={styles.headerAnimalImage}
@@ -297,8 +330,60 @@ const ChatRoom = () => {
           >
             공고로 이동
           </button>
+          <img
+            src={kebabMenu}
+            alt="메뉴"
+            className={styles.kebabMenu}
+            onClick={() => setIsModalOpen(true)}
+          />
         </div>
         
+        {/* 메뉴 모달 */}
+        {isModalOpen && (
+          <div className={styles.modalOverlay} onClick={() => setIsModalOpen(false)}>
+            <div className={styles.modal} onClick={e => e.stopPropagation()}>
+              <button 
+                className={styles.modalButton}
+                onClick={() => {
+                  setIsModalOpen(false);
+                  navigate('/lostAnimal');
+                }}
+              >
+                다른 실종 공고 찾기
+              </button>
+              <button 
+                className={styles.modalButton}
+                onClick={handleDeactivateChat}
+              >
+                채팅 비활성화
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* 확인 모달 */}
+        {isConfirmModalOpen && (
+          <div className={styles.modalOverlay} onClick={() => setIsConfirmModalOpen(false)}>
+            <div className={styles.modal} onClick={e => e.stopPropagation()}>
+              <p>더 이상 상대와 채팅하지 않으실 예정인가요? 채팅방이 즉시 비활성화 됩니다!</p>
+              <div className={styles.modalButtons}>
+                <button 
+                  className={styles.confirmButton}
+                  onClick={confirmDeactivation}
+                >
+                  예
+                </button>
+                <button 
+                  className={styles.cancelButton}
+                  onClick={() => setIsConfirmModalOpen(false)}
+                >
+                  아니요
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+
         <div className={styles.messagesContainer}>
           {renderMessagesWithDateDivider(messages)}
           <div ref={messagesEndRef} />

--- a/src/components/chat/ChatRoom.module.css
+++ b/src/components/chat/ChatRoom.module.css
@@ -6,7 +6,7 @@
 
 
 .main-content, .chatRoom, .messagesContainer {
-  min-height: 0 !important;
+  min-height: 70vh !important;
 }
 
 .main-content, .chatRoom {
@@ -365,4 +365,32 @@
   border: none;
   border-radius: 4px;
   cursor: pointer;
+}
+
+.welcomeModal {
+  max-width: 500px;
+  width: 90%;
+}
+
+.welcomeContent {
+  margin-bottom: 2rem;
+}
+
+.welcomeContent p {
+  margin: 1rem 0;
+  line-height: 1.5;
+  color: #333;
+}
+
+.welcomeCloseButton {
+  display: block;
+  width: 120px;
+  margin: 0 auto;
+  padding: 0.8rem 2rem;
+  background-color: #3581B8;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1rem;
 }

--- a/src/components/chat/ChatRoom.module.css
+++ b/src/components/chat/ChatRoom.module.css
@@ -14,20 +14,17 @@
 }
 
 .main-content {
-  overflow: hidden !important;
-  height: 100vh !important;
-  min-height: 0 !important;
+  height: 100%;
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
-  /* 필요하다면 padding, margin도 0으로 */
-  padding: 0 !important;
-  margin: 0 !important;
+  padding: 0;
+  margin: 0;
   box-sizing: border-box;
 }
 
 .chatRoom {
-  height: 100%;
-  min-height: 0;
+  flex: 1;
   display: flex;
   flex-direction: column;
   background: #f5f5f5;
@@ -68,9 +65,8 @@
 }
 
 .messagesContainer {
-  flex: 1 1 0 !important;
-  overflow-y: auto !important;
-  max-height: 100% !important;
+  flex: 1;
+  padding: 1rem;
 }
 
 .message {

--- a/src/components/chat/ChatRoom.module.css
+++ b/src/components/chat/ChatRoom.module.css
@@ -14,13 +14,10 @@
 }
 
 .main-content {
-  height: 100%;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  padding: 0;
+  padding-top: 0;
   margin: 0;
-  box-sizing: border-box;
+  min-height: 100vh;
+  background: #f5f5f5;
 }
 
 .chatRoom {
@@ -31,6 +28,11 @@
 }
 
 .chatHeader {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1000;
   display: flex;
   align-items: center;
   padding: 1rem;
@@ -39,9 +41,9 @@
 }
 
 .headerAnimalImage {
-  width: 48px;
-  height: 48px;
-  border-radius: 50%;
+  width: 60px;
+  height: 60px;
+  border-radius: 8px;
   object-fit: cover;
   margin-right: 1rem;
 }
@@ -65,7 +67,8 @@
 }
 
 .messagesContainer {
-  flex: 1;
+  margin-top: 80px;
+  margin-bottom: 80px;
   padding: 1rem;
 }
 
@@ -137,6 +140,11 @@
 }
 
 .inputForm {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 1000;
   display: flex;
   gap: 0.5rem;
   padding: 1rem;
@@ -283,4 +291,78 @@
 
 .goToPostButton:hover {
   background-color: #A71F24;
+}
+
+.backButton {
+  width: 24px;
+  height: 24px;
+  cursor: pointer;
+  margin-right: 1rem;
+}
+
+.kebabMenu {
+  width: 24px;
+  height: 24px;
+  cursor: pointer;
+  margin-left: 1rem;
+}
+
+.modalOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 2000;
+}
+
+.modal {
+  background: white;
+  padding: 1.5rem;
+  border-radius: 8px;
+  min-width: 300px;
+}
+
+.modalButton {
+  display: block;
+  width: 100%;
+  padding: 1rem;
+  margin: 0.5rem 0;
+  border: none;
+  background: none;
+  text-align: left;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+.modalButton:hover {
+  background-color: #f5f5f5;
+}
+
+.modalButtons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.confirmButton {
+  padding: 0.5rem 1rem;
+  background-color: #3581B8;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.cancelButton {
+  padding: 0.5rem 1rem;
+  background-color: #f5f5f5;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
 }


### PR DESCRIPTION
### Pull Request 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 페이지 구현
- [x] API 연동
- [x] 버그 수정
- [x] UI/UX 개선
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) fix/#61 -> develop

### 변경 사항
원래 채팅방 이중 스크롤만 제거하는 pr이었으나 채팅방 전반적인 작업이 추가됐습니다.
- 마이페이지 찜 목록 화살표 색상을 변경했습니다.
- 채팅방 이중 스크롤을 제거했습니다
- 헤더에 뒤로가기 버튼, 공고 이동 버튼, 케밥 메뉴 (다른 공고 확인 및 채팅방 비활성화) 기능 추가

### PR 체크리스트
- [x] 디자인이랑 일치하나요?
- [x] 빌드는 성공했나요?
- [ ] 코드 포맷팅을 진행했나요?
- [ ] 컴포넌트의 재사용성을 고려했나요?
- [ ] 반응형 디자인을 적용했나요?

### 스크린샷
- 찜 목록 화살표
<img width="862" alt="image" src="https://github.com/user-attachments/assets/883c83b9-1d4e-4b05-816b-58d84b069d4e" />

- 채팅방 화면
<img width="539" alt="image" src="https://github.com/user-attachments/assets/f7410b60-7125-47c3-ae33-6a3bd13eb4e0" />

- 케밥메뉴
<img width="501" alt="image" src="https://github.com/user-attachments/assets/2f079e1e-159c-4ab4-8807-f401882988cd" />

- 채팅방 비활성화 '예'
<img width="758" alt="image" src="https://github.com/user-attachments/assets/c7d12cff-4759-424f-a0b8-2463c36eb46d" />


### 추가 설명